### PR TITLE
OSOE-641: Fix remaining issues for the Orchard Core 1.6 upgrade in Hosting-Build-Version-Display

### DIFF
--- a/Lombiq.Hosting.BuildVersionDisplay.Tests.UI/Lombiq.Hosting.BuildVersionDisplay.Tests.UI.csproj
+++ b/Lombiq.Hosting.BuildVersionDisplay.Tests.UI/Lombiq.Hosting.BuildVersionDisplay.Tests.UI.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.Tests.UI" Version="6.0.2-alpha.2.osoe-548" />
+    <PackageReference Include="Lombiq.Tests.UI" Version="6.0.2-alpha.1.osoe-641" />
   </ItemGroup>
 
 </Project>

--- a/Lombiq.Hosting.BuildVersionDisplay/Lombiq.Hosting.BuildVersionDisplay.csproj
+++ b/Lombiq.Hosting.BuildVersionDisplay/Lombiq.Hosting.BuildVersionDisplay.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.1.3-alpha.1.osoe-548" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.1.3-alpha.3.osoe-641" />
   </ItemGroup>
 
   <!-- The targets file will be automatically imported when using the project from NuGet but needs an explicit import


### PR DESCRIPTION
[OSOE-641](https://lombiq.atlassian.net/browse/OSOE-641)
Upgrading Lombiq.Tests.UI.* package reference version

[OSOE-641]: https://lombiq.atlassian.net/browse/OSOE-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ